### PR TITLE
Added tags to call individual sub-components.

### DIFF
--- a/modsecSetup.yaml
+++ b/modsecSetup.yaml
@@ -1,30 +1,69 @@
 ---
+- hosts: localhost #Specify hosts from Ansible config here.
+  vars:
+      ScratchLocation: "/tmp" # Location to install ModSec.
+
+  tasks:
+
+    - name: Install dependencies for Apache based instance.   
+      tags: dependency_install 
+      apt: pkg={{ item }} update_cache=true
+      with_items:
+            - libxml2 
+            - libxml2-dev 
+            - libxml2-utils 
+            - libaprutil1 
+            - libaprutil1-dev 
+            - libapache-mod-security
+
+
     # Clone the ModSecurity Repo into our scratch
     - name: Clone ModSec Repo
       git: repo=git://github.com/SpiderLabs/ModSecurity/
            dest="{{ ScratchLocation }}/ModSecurity"
            version=HEAD
            update=no
+
     # Install ModSecurity
     - name: Check if configure already exists
+      tags: 
+        - install
       stat: path="{{ ScratchLocation }}/ModSecurity/configure"
       register: configureStat
+
     - name: Run autogen.sh
+      tags: 
+        - autogen
       command: ./autogen.sh chdir="{{ ScratchLocation }}/ModSecurity"
       when: not configureStat.stat.exists
+
     - name: Check if Makefile already exists
+      tags:
+          - check_modsec_exist
       stat: path="{{ ScratchLocation }}/ModSecurity/Makefile"
       register: makeStat
+
     - name: Run ./configure
+      tags:
+          - configure
       command: ./configure chdir="{{ ScratchLocation }}/ModSecurity"
       when: not makeStat.stat.exists
+
     # Currently a bug in Ansible
     - name: Check if mod_security2.so already exists
+      tags:
+          - so_check
       stat: path="{{ ScratchLocation }}/apache2/.libs/mod_security2.so"
       register: soStat
+
     - name: Run make
+      tags:
+          - make
       command: make chdir="{{ ScratchLocation }}/ModSecurity"
       when: not soStat.stat.exists
+
     - name: run Make install
+      tags:
+          - make_install
       command: make install chdir="{{ ScratchLocation }}/ModSecurity"
       when: not soStat.stat.exists


### PR DESCRIPTION
With the `tag` key word, you can specify individual components to call. This way if something fails, the user can re-execute an individual component rather than re-run the entire playbook.

An example requiring sudo (with the -K flag) is below.

```
ansible-playbook -i /etc/ansible/hosts --tag make modsecSetup.yaml -K
```
